### PR TITLE
Update supported platforms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ repository installed by pip.
    conda env create -f environment.yml
 ```
 
-_Note_. Currently we only support Linux. This is due to how we install
+_Note_. Currently we support Linux and MacOS but not Windows. This is due to how we install
 [pymomentum](https://github.com/facebookincubator/momentum). This dependency is
 used to load the parametric mesh model for body motion. If your workflow does
 not require this modality, removing pymomentum should be sufficient to get the
-code running on Windows and MacOS.
+code running on Windows.
 
 ### Download dataset
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pillow
   - click
   - requests
-  - pymomentum
+  - pymomentum>=0.1.15
   - tqdm
   - pip
   - pip:


### PR DESCRIPTION
Now that the pymomentum has added macOS support (https://github.com/facebookincubator/momentum/pull/115), update the `README` and `environment.yaml` accordingly.