### PR TITLE
Remove note about Windows restrictions due to Momentum

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ repository installed by pip.
    conda env create -f environment.yml
 ```
 
-_Note_. Currently we support Linux and MacOS but not Windows. This is due to how we install
-[pymomentum](https://github.com/facebookincubator/momentum). This dependency is
-used to load the parametric mesh model for body motion. If your workflow does
-not require this modality, removing pymomentum should be sufficient to get the
-code running on Windows.
-
 ### Download dataset
 
 Review the dataset [LICENSE](./LICENSE) to ensure your use case is covered.

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pillow
   - click
   - requests
-  - pymomentum>=0.1.15
+  - pymomentum>=0.1.33
   - tqdm
   - pip
   - pip:


### PR DESCRIPTION
Exciting news! Momentum is now available on Windows! 🎉 Let's remove the note in `README.md` regarding the previous Windows restriction due to Momentum.

https://anaconda.org/conda-forge/pymomentum

